### PR TITLE
fix(useCategories): handle empty search query by trimming whitespace

### DIFF
--- a/frontend/src/hooks/useCategories.ts
+++ b/frontend/src/hooks/useCategories.ts
@@ -75,8 +75,10 @@ export function useCategories(): UseCategoriesReturn {
 
   useEffect(() => {
     const timeoutId = setTimeout(() => {
-      if (searchQuery !== '') {
+      if (searchQuery.trim() !== '') {
         searchCategories(searchQuery);
+      } else {
+        searchCategories('');
       }
     }, 300);
 


### PR DESCRIPTION
Ensure search is triggered even when search query is empty after trimming whitespace